### PR TITLE
Some usability enhancements

### DIFF
--- a/flag.lisp
+++ b/flag.lisp
@@ -80,9 +80,16 @@ string."))
   (with-output-to-string (stream)
     (write-string prefix stream)
     (loop with max-flag-length =
-	 (reduce #'max *registered-flags* :key (lambda (x) (length (car x))) :initial-value 0)
+	 (reduce #'max *registered-flags* 
+		 :key (lambda (x)
+			(destructuring-bind (selector . flag) x
+			  (+ (if (boolean-flag-p flag) 2 0)
+			     (length selector))))
+		 :initial-value 0)
        for (selector . flag) in (reverse *registered-flags*) do ;; reverse so the usage is in order of definition.
-	 (format stream "~&  --~a~v@T ~A~%" selector (- max-flag-length (length selector)) (help flag)))
+	 (format stream "~&  --~a~v@T ~A~%" selector (- max-flag-length (length selector)) (help flag))
+	 (when (boolean-flag-p flag) ;; handle the --no<selector> for booleans.
+	   (format stream "  --no~a~v@T~%"  selector (+ 2 (- max-flag-length (length selector))))))
     (write-string suffix stream)))
        
 ;;; Parsers that convert strings into basic types.

--- a/package.lisp
+++ b/package.lisp
@@ -32,7 +32,7 @@
 
 (defpackage #:com.google.flag
   (:documentation "Command line flag parsing.")
-  (:nicknames :gflag)
+  (:nicknames :gflags)
   (:use #:common-lisp #:com.google.base)
   (:export #:command-line
            #:define-flag

--- a/package.lisp
+++ b/package.lisp
@@ -32,7 +32,9 @@
 
 (defpackage #:com.google.flag
   (:documentation "Command line flag parsing.")
+  (:nicknames :gflag)
   (:use #:common-lisp #:com.google.base)
   (:export #:command-line
            #:define-flag
+	   #:generate-usage-string
            #:parse-command-line))


### PR DESCRIPTION
1. Added package nickname :gflags.
2. Added allegro support to (command-line)
3. Made define-flag return the flag symbol (mimicking defparameter)
4. Made register-flag delete obsolete flags (for 5. below).
5. Added generate-usage-string function which uses the flag names and
   help strings.

With a little more work this library will be better than other getopt libraries. Nice. :-)
